### PR TITLE
Fix detecting resource name with inhereted resources

### DIFF
--- a/lib/cancan/inherited_resource.rb
+++ b/lib/cancan/inherited_resource.rb
@@ -16,5 +16,9 @@ module CanCan
     def resource_base
       @controller.send :end_of_association_chain
     end
+    
+    def name_from_controller
+      @controller.send(:resources_configuration).fetch(:self).fetch(:request_name)
+    end
   end
 end

--- a/spec/cancan/inherited_resource_spec.rb
+++ b/spec/cancan/inherited_resource_spec.rb
@@ -9,6 +9,7 @@ describe CanCan::InheritedResource do
     stub(@controller).params { @params }
     stub(@controller).current_ability { @ability }
     stub(@controller_class).cancan_skipper { {:authorize => {}, :load => {}} }
+    stub(@controller).resources_configuration { { :self => { :request_name => 'project' } } }
   end
 
   it "show should load resource through @controller.resource" do


### PR DESCRIPTION
When controller has custom resource_class, method parent? returns wrong value.
